### PR TITLE
file path choose option added and delete file issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm install @pixelbin/strapi-provider-upload --save
 | Parameter  | Description | Example |
 | ------------- | ------------- | ------------- |
 | PIXELBIN_SECRET | api secret | `a89a57f1-09f3-4z56-a282-4a746ce6cb6e` |
+| folderName | Default path | "strapi-images" |
 
 ## Example
 
@@ -42,7 +43,7 @@ After successful installation your package.json file will have a code:
 ```
 "dependencies": {
     ...
-    "@pixelbin/strapi-provider-upload": "^1.0.1",
+    "@pixelbin/strapi-provider-upload": "^1.0.2",
     ...
   },
 ```
@@ -62,6 +63,7 @@ module.exports = ({ env }) => ({
       provider: "@pixelbin/strapi-provider-upload",
       providerOptions: {
         apiSecret: env("PIXELBIN_SECRET"),
+        folderName: "strapi-images", //you can changes folder name anything you want
       },
       actionOptions: {
         upload: {},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixelbin/strapi-provider-upload",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Pixelbin provider for strapi upload",
   "private": false,
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ module.exports = {
     const { PixelbinConfig, PixelbinClient } = require("@pixelbin/admin");
     const pixelbinConfig = new PixelbinConfig(config);
     const pixelbinClient = new PixelbinClient(pixelbinConfig);
-    const defaultPath = config.folderName || "strapi-images";
+    const DEFAULT_PATH = "strapi-images";
+    const folderPath = config.folderName || DEFAULT_PATH;
     
     // Helper function to extract the data after 'original/'
     const extractData = (url) => {
@@ -35,7 +36,7 @@ module.exports = {
           options: {
             originalFilename: file.name,
           },
-          path: defaultPath,
+          path: folderPath,
           name: file.name,
           overwrite: true,
           ...customParams,

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ module.exports = {
     const { PixelbinConfig, PixelbinClient } = require("@pixelbin/admin");
     const pixelbinConfig = new PixelbinConfig(config);
     const pixelbinClient = new PixelbinClient(pixelbinConfig);
-
+    const defaultPath = config.folderName || "strapi-images";
+    
     return {
       async upload(file, customParams = {}) {
         // Ensure necessary properties are defined
@@ -25,6 +26,8 @@ module.exports = {
           options: {
             originalFilename: file.name,
           },
+          path: defaultPath,
+          name: file.name,
           overwrite: true,
           ...customParams,
         };
@@ -53,7 +56,7 @@ module.exports = {
         }
 
         const response = await pixelbinClient.assets.deleteFile({
-          fileId: `${file.hash}.${file.ext}`,
+          fileId: `${defaultPath}/${file.name}`,
           ...customParams,
         });
 


### PR DESCRIPTION
This pull request introduces a new configuration option to the Strapi upload provider for Pixelbin.io. We have added the ability to specify a default folder path for uploads, providing more flexibility and organization for users.

Changes Made:

1. Configuration Update:
- Added a new parameter folderName in config/plugins.js to allow users to set a default path for uploads
- Updated the README.md file to include instructions on how to use the new folderName configuration.

2. Code Modifications:
- Modified the upload function to use the folderName parameter as the default path if no custom path is provided.
- Added handling in the delete function to use the default file path.
- Ensured that the upload and delete functions validated necessary properties before proceeding.

3. ReadMe Update:
- Documented the new folderName configuration option in the README.md file.
- Provided an example of how to configure and use the folderName parameter.
- Included detailed steps for installing, configuring.

4. Why These Changes Were Made:

- Enhanced Flexibility: Allowing users to specify a default folder path for uploads helps in organizing files better and avoiding clutter.
- Improved User Experience: Users now have the option to either use a default path or specify a custom path, providing more control over file management.
- Documentation: Clear documentation helps users understand how to configure and use the new feature effectively, reducing potential setup issues.